### PR TITLE
Add colored terminal output and improve script messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ add_compile_options(
     -Wno-unused-parameter
     -Wno-unused-variable
     -Wno-type-limits
+    -Wno-empty-body
+    -Wno-sign-compare
 )
 if(UNIX AND NOT APPLE)
     add_compile_options(-I/usr/arm-none-eabi/include)

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -9,45 +9,49 @@ while [ ! -f "$PROJECT_DIR/CMakeLists.txt" ]; do
   PROJECT_DIR=$(dirname "$PROJECT_DIR")
   # 防止无限循环
   if [ "$PROJECT_DIR" = "/" ]; then
-    echo "Error: Could not find CMakeLists.txt in any parent directory."
+    echo -e "\033[31mError: Could not find CMakeLists.txt in any parent directory.\033[0m"
     exit 1
   fi
 done
 
 # 从CMakeLists.txt文件中提取项目名称
 CMAKE_PROJECT_NAME=$(grep -E "set\(CMAKE_PROJECT_NAME" "$PROJECT_DIR/CMakeLists.txt" | sed -E 's/set\(CMAKE_PROJECT_NAME[[:space:]]+([^)]+)\)/\1/' | tr -d ' ')
-echo "Project root directory: $PROJECT_DIR"
-echo "Project name from CMakeLists.txt: $CMAKE_PROJECT_NAME"
+echo -e "\033[36mProject root directory: $PROJECT_DIR\033[0m"
+echo -e "\033[36mProject name from CMakeLists.txt: $CMAKE_PROJECT_NAME\033[0m"
 
-# 设置构建类型(默认为Release，可通过参数修改)
+# 设置构建类型(默认为Debug，可通过参数修改)
 BUILD_TYPE="Debug"
-if [ "$1" == "release" ] || [ "$1" == "Release" ]; then
+if [ "$1" == "debug" ] || [ "$1" == "Debug" ]; then
+  BUILD_TYPE="Debug"
+  shift # 移除参数
+elif [ "$1" == "release" ] || [ "$1" == "Release" ]; then
   BUILD_TYPE="Release"
+  shift # 移除参数
 fi
-echo "Build type: $BUILD_TYPE"
+echo -e "\033[35mBuild type: $BUILD_TYPE\033[0m"
 
 # 创建并进入构建目录
 BUILD_DIR="$PROJECT_DIR/build"
 mkdir -p "$BUILD_DIR"
-cd "$BUILD_DIR" || { echo "Failed to enter build directory"; exit 1; }
+cd "$BUILD_DIR" || { echo -e "\033[31mFailed to enter build directory\033[0m"; exit 1; }
 
 # 运行 CMake 配置和编译项目
-echo "Configuring project with CMake..."
+echo -e "\033[36mConfiguring project with CMake...\033[0m"
 if command -v ninja &> /dev/null; then
   # 如果有 Ninja，使用 Ninja 生成器
   cmake .. -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-  echo "Building project with Ninja..."
+  echo -e "\033[35mBuilding project with Ninja...\033[0m"
   ninja -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 else
   # 否则使用默认生成器
   cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-  echo "Building project with Make..."
+  echo -e "\033[35mBuilding project with Make...\033[0m"
   make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 fi
 
 # 检查构建是否成功
 if [ $? -ne 0 ]; then
-  echo "Build failed!"
+  echo -e "\033[31mBuild failed!\033[0m"
   exit 1
 fi
 
@@ -59,15 +63,15 @@ HEX_FILE="$BUILD_DIR/${CMAKE_PROJECT_NAME}.hex"
 # 检查 ELF 文件是否成功生成
 if [ -f "$ELF_FILE" ]; then
   # 将 ELF 文件转换为 BIN 文件和 HEX 文件
-  echo "Converting ELF to BIN and HEX formats..."
+  echo -e "\033[36mConverting ELF to BIN and HEX formats...\033[0m"
   arm-none-eabi-objcopy -O binary "$ELF_FILE" "$BIN_FILE"
   arm-none-eabi-objcopy -O ihex "$ELF_FILE" "$HEX_FILE"
-  echo "Build completed successfully!"
+  echo -e "\033[32mBuild completed successfully!\033[0m"
   echo "Output files:"
-  echo "  ELF: $ELF_FILE"
-  echo "  BIN: $BIN_FILE"
-  echo "  HEX: $HEX_FILE"
+  echo -e "\033[35m  ELF: $ELF_FILE\033[0m"
+  echo -e "\033[35m  BIN: $BIN_FILE\033[0m"
+  echo -e "\033[35m  HEX: $HEX_FILE\033[0m"
 else
-  echo "Error: ELF file not found. Compilation might have failed."
+  echo -e "\033[31mError: ELF file not found. Compilation might have failed.\033[0m"
   exit 1
 fi

--- a/Scripts/clean.sh
+++ b/Scripts/clean.sh
@@ -9,45 +9,45 @@ while [ ! -f "$PROJECT_DIR/CMakeLists.txt" ]; do
   PROJECT_DIR=$(dirname "$PROJECT_DIR")
   # 防止无限循环
   if [ "$PROJECT_DIR" = "/" ]; then
-    echo "Error: Could not find CMakeLists.txt in any parent directory."
+    echo -e "\033[31mError: Could not find CMakeLists.txt in any parent directory.\033[0m"
     exit 1
   fi
 done
 
-echo "Project root directory: $PROJECT_DIR"
+echo -e "\033[36mProject root directory: $PROJECT_DIR\033[0m"
 
 # 设置构建目录
 BUILD_DIR="$PROJECT_DIR/build"
 
 # 检查构建目录是否存在
 if [ -d "$BUILD_DIR" ]; then
-  echo "Cleaning build directory: $BUILD_DIR"
-  
+  echo -e "\033[36mCleaning build directory: $BUILD_DIR\033[0m"
+
   # 在Windows Git Bash中使用rm -rf可能会有问题，所以先尝试用原生命令
   if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     # 在Windows环境中使用rmdir命令
     BUILD_DIR_WIN=$(cygpath -w "$BUILD_DIR")
-    echo "Running on Windows, converted path: $BUILD_DIR_WIN"
-    
+    echo -e "\033[35mRunning on Windows, converted path: $BUILD_DIR_WIN\033[0m"
+
     rm -rf "$BUILD_DIR"
   else
     # 在Linux/macOS上直接使用rm -rf
     rm -rf "$BUILD_DIR"
   fi
-  
+
   # 检查清理结果
   if [ ! -d "$BUILD_DIR" ]; then
-    echo "Clean completed successfully!"
+    echo -e "\033[32mClean completed successfully!\033[0m"
   else
-    echo "Warning: Could not completely remove the build directory."
-    echo "Some files may still exist. You might need to manually delete them."
+    echo -e "\033[33mWarning: Could not completely remove the build directory.\033[0m"
+    echo -e "\033[33mSome files may still exist. You might need to manually delete them.\033[0m"
   fi
 else
-  echo "Build directory does not exist. Nothing to clean."
+  echo -e "\033[33mBuild directory does not exist. Nothing to clean.\033[0m"
 fi
 
 # 清理其他可能的生成文件
-echo "Cleaning other generated files..."
+echo -e "\033[36mCleaning other generated files...\033[0m"
 
 # 清理可能存在的CMake缓存文件
 find "$PROJECT_DIR" -name "CMakeCache.txt" -type f -delete
@@ -63,4 +63,4 @@ find "$PROJECT_DIR" -name "*.hex" -type f -delete
 find "$PROJECT_DIR" -name "*.bin" -type f -delete
 find "$PROJECT_DIR" -name "*.map" -type f -delete
 
-echo "===== 清理操作完成 ====="
+echo -e "\033[36m===== 清理操作完成 =====\033[0m"

--- a/Scripts/flash.sh
+++ b/Scripts/flash.sh
@@ -16,8 +16,8 @@ done
 
 # 从CMakeLists.txt文件中提取项目名称
 CMAKE_PROJECT_NAME=$(grep -E "set\(CMAKE_PROJECT_NAME" "$PROJECT_DIR/CMakeLists.txt" | sed -E 's/set\(CMAKE_PROJECT_NAME[[:space:]]+([^)]+)\)/\1/' | tr -d ' ')
-echo "Project root directory: $PROJECT_DIR"
-echo "Project name from CMakeLists.txt: $CMAKE_PROJECT_NAME"
+echo -e "\033[36mProject root directory: $PROJECT_DIR\033[0m"
+echo -e "\033[36mProject name from CMakeLists.txt: $CMAKE_PROJECT_NAME\033[0m"
 
 # 设置构建目录和HEX文件路径
 BUILD_DIR="$PROJECT_DIR/build"
@@ -35,7 +35,7 @@ if [ ! -f "$HEX_FILE" ]; then
   exit 1
 fi
 
-echo "Using HEX file: $HEX_FILE"
+echo -e "\033[35mUsing HEX file: $HEX_FILE\033[0m"
 
 # 在 Windows Git Bash 中运行时，转换路径格式
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
@@ -43,7 +43,7 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
   HEX_FILE_WIN=$(cygpath -w "$HEX_FILE")
   # 将Windows路径中的反斜杠转换为正斜杠
   HEX_FILE_WIN=${HEX_FILE_WIN//\\/\/}
-  echo "Running on Windows Git Bash, converted path: $HEX_FILE_WIN"
+  echo -e "\033[36mRunning on Windows Git Bash, converted path: $HEX_FILE_WIN\033[0m"
   # 使用转换后的 Windows 路径
   openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c "program \"$HEX_FILE_WIN\" verify reset exit"
 else

--- a/Utils/ssd1306_fonts.h
+++ b/Utils/ssd1306_fonts.h
@@ -19,7 +19,7 @@ extern const SSD1306_Font_t Font_16x26;
 extern const SSD1306_Font_t Font_16x24;
 #endif
 #ifdef SSD1306_INCLUDE_FONT_16x15
-/** Generated Roboto Thin 15 
+/** Generated Roboto Thin 15
  * @copyright Google https://github.com/googlefonts/roboto
  * @license This font is licensed under the Apache License, Version 2.0.
 */

--- a/run.sh
+++ b/run.sh
@@ -10,17 +10,17 @@ CLEAN_SCRIPT="$SCRIPT_DIR/Scripts/clean.sh"
 
 # 检查脚本是否存在
 if [ ! -f "$BUILD_SCRIPT" ]; then
-  echo "Error: Build script not found at $BUILD_SCRIPT"
+  echo -e "\033[31mError: Build script not found at $BUILD_SCRIPT\033[0m"
   exit 1
 fi
 
 if [ ! -f "$FLASH_SCRIPT" ]; then
-  echo "Error: Flash script not found at $FLASH_SCRIPT"
+  echo -e "\033[31mError: Flash script not found at $FLASH_SCRIPT\033[0m"
   exit 1
 fi
 
 if [ ! -f "$CLEAN_SCRIPT" ]; then
-  echo "Error: Clean script not found at $CLEAN_SCRIPT"
+  echo -e "\033[31mError: Clean script not found at $CLEAN_SCRIPT\033[0m"
   exit 1
 fi
 
@@ -31,38 +31,29 @@ chmod +x "$CLEAN_SCRIPT"
 
 # 根据参数执行对应功能
 if [ "$1" == "build" ]; then
-  echo "===== 执行构建操作 ====="
+  echo -e "\033[36m===== 执行构建操作 =====\033[0m"
   # 如果有额外参数，传递给build脚本
-  if [ -n "$2" ]; then
-    "$BUILD_SCRIPT" "$2"
-  else
-    "$BUILD_SCRIPT"
-  fi
+  shift
+  "$BUILD_SCRIPT" "$@"
 elif [ "$1" == "flash" ]; then
-  echo "===== 执行烧录操作 ====="
+  echo -e "\033[36m===== 执行烧录操作 =====\033[0m"
   # 如果有额外参数，传递给flash脚本
-  if [ -n "$2" ]; then
-    "$FLASH_SCRIPT" "$2"
-  else
-    "$FLASH_SCRIPT"
-  fi
+  shift
+  "$FLASH_SCRIPT" "$@"
 elif [ "$1" == "clean" ]; then
-  echo "===== 执行清理操作 ====="
+  echo -e "\033[36m===== 执行清理操作 =====\033[0m"
   "$CLEAN_SCRIPT"
 else
   # 如果没有参数或参数不是build、flash或clean，则依次执行构建和烧录
-  echo "===== 执行构建操作 ====="
-  "$BUILD_SCRIPT" "$1"  # 将第一个参数作为构建类型传递
-  
+  echo -e "\033[36m===== 执行构建操作 =====\033[0m"
+  "$BUILD_SCRIPT" "$@"  # 将第一个参数作为构建类型传递
+
   # 检查构建是否成功
   if [ $? -ne 0 ]; then
-    echo "构建失败，中止烧录操作。"
+    echo -e "\033[31m构建失败，中止烧录操作。\033[0m"
     exit 1
   fi
-  
-  echo "===== 执行烧录操作 ====="
+
+  echo -e "\033[36m===== 执行烧录操作 =====\033[0m"
   "$FLASH_SCRIPT"
 fi
-
-# 如果执行到这里，表示操作已完成
-echo "===== 操作完成 ====="


### PR DESCRIPTION
- Use ANSI escape codes for colored output in all scripts
- Clarify and standardize status and error messages
- Allow passing extra arguments to build and flash scripts via run.sh
- Default build type is now Debug in build.sh
- Add `-Wno-empty-body` and `-Wno-sign-compare` to CMake options